### PR TITLE
Nrow fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ options:
 
 Example: ```python src/main_hmda.py -f "config/hmda_simplified_conventional.yaml" -ts "config/hmda_ts.yaml" -op "output/hmda_simplified_conventional_100.txt" -n 100 -v ```
 
-Note that the number of LAR rows generated (`-n` argument) must match the `lar_count` field in the `hmda_ts.yaml` file or the generated file will be rejected by the platform. 
+The `hmda_ts.yaml` config file generates the first row transmittal sheet of the final submission file. The `lar_count` field is set to empty by default in the config file, but is set to equal the nrows value supplied in the argument options. This is to avoid triggering edit S304. 
 
 ## How to Use the Mock Data Generator for SBL
 The [`main_sbl.py`](https://github.com/cfpb/regtech-mock-data-generator/blob/main/src/main_sbl.py) script will generate mock HMDA data according to supplied a SBLAR YAML config file. It will output a .csv that is appropriately formed to be uploadable to the SBL beta platform for testing. 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ _employer_ is generated using random strings of Lorem Ipsum between the supplied
 The last field, *hispanic_or_latino*, illustrates how `WeightedDiscrete` can be leveraged to sample arbitrary values from a set with specificied relative frequency. Here we're telling the backend to sample from the set {Yes, No} with Yes appearing 5 times more frequently than No. 
 
 Generating a mock dataset with 100 rows can be accomplished using just four lines of code. 
+
 ```python
 from mock_data import MockDataset
 
@@ -108,3 +109,41 @@ The beauty of this is that your data generation script is completely separate fr
 ## Custom Data Backends
 
 todo: illustrate how a custom sublcass could be used to produce instances of Multiple Response for SBL. 
+
+# Generating data
+
+## How to Use the Mock Data Generator for HMDA
+
+The [`main_hmda.py`](https://github.com/cfpb/regtech-mock-data-generator/blob/main/src/main_hmda.py) script will generate mock HMDA data according to supplied LAR YAML config file and transmittal sheet YAML config files. It will output the data as a pipe-separated .txt file with transmittal sheet values as the header followed by the LAR values in a fully-formed file that can be submitted to the beta platform for testing.  
+
+```python
+> python src/main_hmda.py -h
+usage: datagen [-h] [-f LAR_YAML_CONFIG] [-ts TRANSMITTAL_SHEET_YAML_CONFIG] [-op OUTPUT_FILEPATH] [-n NROWS] [-v]
+
+options:
+  -h, --help            show this help message and exit
+  -f, --lar_yaml_config LAR_YAML_CONFIG
+  -ts, --transmittal_sheet_yaml_config TRANSMITTAL_SHEET_YAML_CONFIG
+  -op, --output_filepath OUTPUT_FILEPATH
+  -n, --nrows NROWS
+  -v, --verbose
+```
+
+Example: ```python src/main_hmda.py -f "config/hmda_simplified_conventional.yaml" -ts "config/hmda_ts.yaml" -op "output/hmda_simplified_conventional_100.txt" -n 100 -v ```
+
+## How to Use the Mock Data Generator for SBL
+The [`main_sbl.py`](https://github.com/cfpb/regtech-mock-data-generator/blob/main/src/main_sbl.py) script will generate mock HMDA data according to supplied a SBLAR YAML config file. It will output a .csv that is appropriately formed to be uploadable to the SBL beta platform for testing. 
+
+```python
+> python src/main_sbl.py -h                                                  
+usage: datagen [-h] [-f SBLAR_YAML_CONFIG] [-n NROWS] [-op OUTPUT_FILEPATH] [-v]
+
+options:
+  -h, --help            show this help message and exit
+  -f, --sblar_yaml_config SBLAR_YAML_CONFIG
+  -n, --nrows NROWS
+  -op, --output_filepath OUTPUT_FILEPATH
+  -v, --verbose
+```
+
+Example: ```python src/main_sbl.py -f "config/sbl.yaml" -op "output/sbl_100.csv" -n 100```

--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ options:
 
 Example: ```python src/main_hmda.py -f "config/hmda_simplified_conventional.yaml" -ts "config/hmda_ts.yaml" -op "output/hmda_simplified_conventional_100.txt" -n 100 -v ```
 
+Note that the number of LAR rows generated (`-n` argument) must match the `lar_count` field in the `hmda_ts.yaml` file or the generated file will be rejected by the platform. 
+
 ## How to Use the Mock Data Generator for SBL
 The [`main_sbl.py`](https://github.com/cfpb/regtech-mock-data-generator/blob/main/src/main_sbl.py) script will generate mock HMDA data according to supplied a SBLAR YAML config file. It will output a .csv that is appropriately formed to be uploadable to the SBL beta platform for testing. 
 

--- a/src/README.md
+++ b/src/README.md
@@ -1,6 +1,14 @@
+
+## Correlation
+
 There are five methods of class Correlation, which can be supplied for each variable listed in the yaml spec. Those are: 
-    INDEPENDENT: Not used directly in the yaml spec, but is the default class of most data types supplied. 
-    DIRECTIVE: Must be indicated when a field's population directly affects the population of the value in another field, such as (in SBL) the `amount_applied_for_flag` field, which when populated with thea value of `1` (applicable and reported), _directs_ the `amount_applied_for` numeric to be populated. In this case, the `amount_applied_for_flag` variable's value _directs_ the population of the `amount_applied_for` variable.
-    CASCADING_L1: Must be indicated when a field's value is restricted by the value(s) of another field, which must be indicated in the `dep_field` and `dep_values` fields. For example, in SBL, the value of `ct_loan_term_flag` is restricted by the value of `ct_credit_product`. e.g. the `ct_loan_term_flag` values of `988` (applicable but not provided) and `900` (applicable and reported) are the only values that can be entered when the value of `ct_credit_product` is equal to `1` or `2`, and the `ct_loan_term_flag` value of `999` is the only value that can be entered when the value of `ct_credit_product` is `988` (undetermined or not provided).
-    CASCADING_L2: A more complicated version of the above, to be explained later. 
-    DEPENDENT: Must be indicated when a field's population relies on the value in another field, such as (in SBL) the `amount_applied_for` numeric field which requires a value of `1` (applicable and reported) in the `amount_applied_for_flag` field. In this case, the population of the `amount_applied_for` is _dependent_ on the `amount_applied_for_flag` variable's value. 
+
+**INDEPENDENT**: Not used directly in the yaml spec, but is the default class of most data types supplied. 
+
+**DIRECTIVE**: Must be indicated when a field's population directly affects the population of the value in another field, such as (in SBL) the `amount_applied_for_flag` field, which when populated with thea value of `1` (applicable and reported), _directs_ the `amount_applied_for` numeric to be populated. In this case, the `amount_applied_for_flag` variable's value _directs_ the population of the `amount_applied_for` variable.
+
+**CASCADING_L1**: Must be indicated when a field's value is restricted by the value(s) of another field, which must be indicated in the `dep_field` and `dep_values` fields. For example, in SBL, the value of `ct_loan_term_flag` is restricted by the value of `ct_credit_product`. e.g. the `ct_loan_term_flag` values of `988` (applicable but not provided) and `900` (applicable and reported) are the only values that can be entered when the value of `ct_credit_product` is equal to `1` or `2`, and the `ct_loan_term_flag` value of `999` is the only value that can be entered when the value of `ct_credit_product` is `988` (undetermined or not provided).
+
+**CASCADING_L2**: A more complicated version of the above, to be explained later. 
+
+**DEPENDENT**: Must be indicated when a field's population relies on the value in another field, such as (in SBL) the `amount_applied_for` numeric field which requires a value of `1` (applicable and reported) in the `amount_applied_for_flag` field. In this case, the population of the `amount_applied_for` is _dependent_ on the `amount_applied_for_flag` variable's value. 

--- a/src/config/hmda_simplified_conventional.yaml
+++ b/src/config/hmda_simplified_conventional.yaml
@@ -29,19 +29,10 @@ loan_type:
   WeightedDiscrete:
     population:
       "1": 1 # Conventional
-      # "2": 1 # FHA
-      # "3": 1 # VA
-      # "4": 1 # RHS/USDA
 loan_purpose:
   WeightedDiscrete:
     population:
       "1": 1 # Home Purchase
-      # "2": 1 # Home Improvement
-      # "31": 1 # Refinancing
-      # "32": 1 # Cash-Out Refinancing
-      # "4": 1 # Other purpose
-      # "5": 1 # Not Applicable
-    # correlation: "directive" 
 preapproval:
   WeightedDiscrete:
     population:

--- a/src/config/hmda_ts.yaml
+++ b/src/config/hmda_ts.yaml
@@ -2,7 +2,7 @@
 
 record_identifier: ["1"]
 financial_institution_name: ["Bank1"]
-calendar_year: ["2025"]
+calendar_year: ["2026"]
 calendar_quarter: ["4"]
 contact_name: ["Mr. Smug Pockets"]
 contact_phone: ["555-555-5555"]
@@ -12,6 +12,6 @@ contact_city: ["Tatertown"]
 contact_state: ["UT"]
 contact_zip: ["54096"]
 agency_code: ["9"]
-lar_count: ["100"]
+lar_count: [""] # set by args.nrows in main_hmda.py
 tax_id: ["02-1234567"]
 lei: ["BANK1LEIFORTEST12345"]

--- a/src/config/sbl.yaml
+++ b/src/config/sbl.yaml
@@ -3,6 +3,7 @@
 uid: 
   UniqueID:
     lei: 'BANK1LEIFORTEST12345'
+    min_generate: 1
     max_generate: 25
 app_date:
   BoundedDatetime:

--- a/src/hmda_conventional.ipynb
+++ b/src/hmda_conventional.ipynb
@@ -21,15 +21,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def mock_full_dataset(yaml_file, output_filepath, nrows: int, transmittal_sheet):\n",
-    "    mock = MockDataset.read_yaml_spec(yaml_file)\n",
+    "def mock_full_dataset(\n",
+    "    lar_yaml_config, output_filepath, nrows: int, transmittal_sheet_yaml_config\n",
+    "):\n",
+    "    mock = MockDataset.read_yaml_spec(lar_yaml_config)\n",
     "    mock_df = mock.generate_mock_data(nrows)\n",
     "    # Create and append check digit for the ULI field using the utils.check_digit_gen() tool\n",
     "    mock_df[\"uli\"] = mock_df[\"uli\"] + mock_df[\"uli\"].apply(\n",
     "        lambda x: utils.check_digit_gen(ULI=x)\n",
     "    )\n",
     "    # Read in the transmittal sheet\n",
-    "    with open(transmittal_sheet, \"r\") as file:\n",
+    "    with open(transmittal_sheet_yaml_config, \"r\") as file:\n",
     "        ts = yaml.safe_load(file)\n",
     "    ts_df = pd.DataFrame(ts)\n",
     "    # Write the file out as a .txt following HMDA file format - TS as first row, LAR as subsequent rows\n",
@@ -46,10 +48,10 @@
     "# Run the function with your specified outputs.\n",
     "\n",
     "mock_full_dataset(\n",
-    "    yaml_file=\"config/hmda_simplified_conventional.yaml\",\n",
+    "    lar_yaml_config=\"config/hmda_simplified_conventional.yaml\",\n",
     "    output_filepath=\"output/hmda_simplified_conventional.txt\",\n",
     "    nrows=100,  # should match the lar_count in hmda_ts.yaml\n",
-    "    transmittal_sheet=\"config/hmda_ts.yaml\",\n",
+    "    transmittal_sheet_yaml_config=\"config/hmda_ts.yaml\",\n",
     ")"
    ]
   }

--- a/src/hmda_conventional.ipynb
+++ b/src/hmda_conventional.ipynb
@@ -34,6 +34,7 @@
     "    with open(transmittal_sheet_yaml_config, \"r\") as file:\n",
     "        ts = yaml.safe_load(file)\n",
     "    ts_df = pd.DataFrame(ts)\n",
+    "    ts_df[\"lar_count\"] = nrows\n",
     "    # Write the file out as a .txt following HMDA file format - TS as first row, LAR as subsequent rows\n",
     "    utils.write_file(outpath=output_filepath, ts_input=ts_df, lar_input=mock_df)"
    ]
@@ -50,7 +51,7 @@
     "mock_full_dataset(\n",
     "    lar_yaml_config=\"config/hmda_simplified_conventional.yaml\",\n",
     "    output_filepath=\"output/hmda_simplified_conventional.txt\",\n",
-    "    nrows=100,  # should match the lar_count in hmda_ts.yaml\n",
+    "    nrows=100,\n",
     "    transmittal_sheet_yaml_config=\"config/hmda_ts.yaml\",\n",
     ")"
    ]

--- a/src/main_hmda.py
+++ b/src/main_hmda.py
@@ -12,10 +12,9 @@ from mock_data import MockDataset
 from mock_data import utils
 
 parser = argparse.ArgumentParser('datagen')
-parser.add_argument('-f', '--yaml_file')
-parser.add_argument('-ts', '--transmittal_sheet')
+parser.add_argument('-f', '--lar_yaml_config')
+parser.add_argument('-ts', '--transmittal_sheet_yaml_config')
 parser.add_argument('-op', '--output_filepath')
-parser.add_argument('-of', '--output_filename')
 parser.add_argument('-n', '--nrows', type=int, default=100)
 parser.add_argument('-v', '--verbose', action='store_true')
 args = parser.parse_args()
@@ -28,7 +27,7 @@ os.chdir(os.path.dirname(__file__))
 
 random.seed()
 
-mock = MockDataset.read_yaml_spec(args.yaml_file)
+mock = MockDataset.read_yaml_spec(args.lar_yaml_config)
 
 mock_df = mock.generate_mock_data(args.nrows)
 
@@ -38,7 +37,7 @@ mock_df["uli"] = mock_df["uli"] + mock_df["uli"].apply(
 )
 
 # Read in the transmittal sheet
-with open(args.transmittal_sheet, "r") as file:
+with open(args.transmittal_sheet_yaml_config, "r") as file:
     ts = yaml.safe_load(file)
 ts_df = pd.DataFrame(ts)
 

--- a/src/main_hmda.py
+++ b/src/main_hmda.py
@@ -40,6 +40,7 @@ mock_df["uli"] = mock_df["uli"] + mock_df["uli"].apply(
 with open(args.transmittal_sheet_yaml_config, "r") as file:
     ts = yaml.safe_load(file)
 ts_df = pd.DataFrame(ts)
+ts_df['lar_count'] = args.nrows
 
 # Write the file out as a .txt following HMDA file format - TS as first row, LAR as subsequent rows
 utils.write_file(

--- a/src/main_sbl.py
+++ b/src/main_sbl.py
@@ -6,8 +6,9 @@ import random
 from mock_data import MockDataset
 
 parser = argparse.ArgumentParser('datagen')
+parser.add_argument('-f', '--sblar_yaml_config')
 parser.add_argument('-n', '--nrows', type=int, default=100)
-parser.add_argument('-o', '--outputfile', default="output/sbl.csv")
+parser.add_argument('-op', '--output_filepath', default="output/sbl.csv")
 parser.add_argument('-v', '--verbose', action='store_true')
 args = parser.parse_args()
 
@@ -19,8 +20,8 @@ os.chdir(os.path.dirname(__file__))
 
 random.seed()
 
-mock = MockDataset.read_yaml_spec("config/sbl.yaml")
+mock = MockDataset.read_yaml_spec(args.sblar_yaml_config)
 
 mock_df = mock.generate_mock_data(args.nrows)
 
-mock_df.to_csv(args.outputfile, index=False)
+mock_df.to_csv(args.output_filepath, index=False)

--- a/src/mock_data/MockDataset.py
+++ b/src/mock_data/MockDataset.py
@@ -115,7 +115,7 @@ class MockDataset:
         with open(path, "r") as f:
             raw_spec = yaml.safe_load(f)
 
-        logger.info(f"Dataset will have the following ields: {list(raw_spec.keys())}")
+        logger.info(f"Dataset will have the following fields: {list(raw_spec.keys())}")
 
         # this will be populated as the yaml is parsed. Maps field to Backend object
         spec_dict = {}


### PR DESCRIPTION
This lets a user set the `lar_count` transmittal sheet variable using the `args.nrows` option instead of having to manually set it in both the `hmda_ts.yaml` and `nrows` arg. This is a convenience feature that makes the data gen workflow smoother. 